### PR TITLE
Enh: Implement custom UnmarshalJSON method for Meta struct to handle …

### DIFF
--- a/entity/meta.go
+++ b/entity/meta.go
@@ -1,7 +1,32 @@
 package entity
 
+import "encoding/json"
+
 type Meta struct {
 	ID    int    `json:"id"`
 	Key   string `json:"key"`
 	Value string `json:"value"`
+}
+
+func (m *Meta) UnmarshalJSON(data []byte) error {
+	type Alias Meta
+	aux := &struct {
+		Value json.RawMessage `json:"value"`
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	var str string
+	if err := json.Unmarshal(aux.Value, &str); err == nil {
+		m.Value = str
+		return nil
+	}
+
+	m.Value = string(aux.Value)
+	return nil
 }


### PR DESCRIPTION
Previously, `MetaData.Value` would cause an error during JSON unmarshaling if the value was not a simple string (e.g., a nested object or array). This patch adds a custom `UnmarshalJSON` method to safely convert such values into a string format.

This ensures compatibility with WooCommerce metadata where the value can vary in structure.

No breaking changes introduced.